### PR TITLE
fix: package.json URLs and downloadReleaseAsset script (ECO-967)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ git submodule update --init --recursive
 
 ### Using emscripten bindings
 
+```bash
+yarn add @fetchai/blst-ts
+# or
+npm install --save @fetchai/blst-ts
+```
+
 #### `package.json`:
 ```javascript
 depencencies: {
-  "@chainsafe/blst": "git+https://github.com/fechai/blst-ts#feat/browser-support",
+  "@fetchai/blst-ts": "^0.3.1",
   ...
 }
 ```

--- a/package.json
+++ b/package.json
@@ -25,15 +25,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ChainSafe/blst-ts.git"
+    "url": "git+https://github.com/fetchai/blst-ts.git"
   },
   "keywords": [],
   "author": "ChainSafe Systems",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/ChainSafe/blst-ts/issues"
+    "url": "https://github.com/fetchai/blst-ts/issues"
   },
-  "homepage": "https://github.com/ChainSafe/blst-ts#readme",
+  "homepage": "https://github.com/fetchai/blst-ts#readme",
   "devDependencies": {
     "@types/chai": "^4.2.13",
     "@types/js-yaml": "^4.0.5",

--- a/src/scripts/downloadReleaseAsset.ts
+++ b/src/scripts/downloadReleaseAsset.ts
@@ -3,7 +3,7 @@ import fetch from "node-fetch";
 import {PACKAGE_JSON_PATH} from "./paths";
 import {ensureDirFromFilepath} from "./paths_node";
 
-const githubReleasesDownloadUrl = "https://github.com/ChainSafe/blst-ts/releases/download";
+const githubReleasesDownloadUrl = "https://github.com/fetchai/blst-ts/releases/download";
 
 export async function downloadReleaseAsset(assetName: string, binaryPath: string): Promise<void> {
   // eslint-disable-next-line


### PR DESCRIPTION
### Changes

- updates package.json URLs:
  - repository
  - bugs
  - homepage
- updates readme "how to use" section with our npm package
- fixes downloadReleaseAsset script